### PR TITLE
Now checks converted files

### DIFF
--- a/src/jshint.plugin.coffee
+++ b/src/jshint.plugin.coffee
@@ -67,7 +67,7 @@ module.exports = (BasePlugin) ->
           tooManyErrors = false
           
           # Find JS files
-          if file.extension is 'js'
+          if file.outExtension is 'js'
             
             # Skip files in ignored paths
             for path in ignoredPaths
@@ -85,7 +85,7 @@ module.exports = (BasePlugin) ->
                 return
 
             # Skip valid files
-            if jshint(file.source, config.hintOptions, config.globals) is true
+            if jshint(file.contentRendered, config.hintOptions, config.globals) is true
               return
 
             else


### PR DESCRIPTION
Fixes a problem where files that were converted TO JS (example.js.eco) wouldn't be linted.
Fixes a bug where files that were converted FROM JS (example.coffee.js) would be linted after conversion.