### PR TITLE
Fixed reading of .jshintrc

### DIFF
--- a/src/jshint.plugin.coffee
+++ b/src/jshint.plugin.coffee
@@ -22,14 +22,15 @@ module.exports = (BasePlugin) ->
 
     docpadReady: () ->
       # Read .jshintrc
+      docpad = @docpad
       fs.readFile process.cwd() + '/.jshintrc', (err, data) ->
         if err
           return 
         else
-          config = @docpad.loadedPlugins.jshint.config
+          config = docpad.loadedPlugins.jshint.config
           jshintrc = JSON.parse(data)
           config.hintOptions = merge(config.hintOptions, jshintrc)
-          @docpad.loadedPlugins.jshint.config = config
+          docpad.loadedPlugins.jshint.config = config
 
           if config.hintOptions.globals
             config.globals = merge(config.globals, config.hintOptions.globals)


### PR DESCRIPTION
This fixes a problem where the call to fs.readFile would change the context of this, making @docpad undefined, causing .jshintrc not to be read.